### PR TITLE
Fix problems in the test suite that don't account for a child discount (children are cheaper than the group rate):

### DIFF
--- a/src/test/java/de/saxsys/dojo/ticketkata/CinemaCashRegisterTest.java
+++ b/src/test/java/de/saxsys/dojo/ticketkata/CinemaCashRegisterTest.java
@@ -369,7 +369,7 @@ public class CinemaCashRegisterTest {
         int age = 12;
         boolean isStudent = false;
 
-        float expResult = 154.0F;
+        float expResult = 144.0F;
 
         CinemaCashRegister instance = new CinemaCashRegister();
         instance.startPurchase(runtime, day, isParquet, is3D);
@@ -395,7 +395,7 @@ public class CinemaCashRegisterTest {
         int age = 12;
         boolean isStudent = false;
 
-        float expResult = 120.00F;
+        float expResult = 111.00F;
 
         CinemaCashRegister instance = new CinemaCashRegister();
         instance.startPurchase(runtime, day, isParquet, is3D);
@@ -420,7 +420,7 @@ public class CinemaCashRegisterTest {
         int age = 12;
         boolean isStudent = false;
 
-        float expResult = 300.00F;
+        float expResult = 297.50F;
 
         CinemaCashRegister instance = new CinemaCashRegister();
         instance.startPurchase(runtime, day, isParquet, is3D);


### PR DESCRIPTION
testPurchasebigEnoughSchoolclassWithTwoTeachers should be 144, not 154 (24 \* 5.5 + 2 \* 6)
testPurchaseTooSmallSchoolclassWithTwoTeachers should be 111, not 120 (18 \* $0.50 child discount missing)
testPurchaseMix should be 297.50 not 300 (5 \* $.50 child discount missing)
